### PR TITLE
Added new formats for parsing time

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -2,20 +2,27 @@
 module Main where
 
 import Criterion.Main
-
 import Time
 import Data.Time
 import qualified Data.Time.Format as DTF
-
+import Data.Text as T
 
 main :: IO ()
 main = do
   let format = "%Y-%m-%dT%k:%M:%SZ"
   let jformat = "%Y-%m-%dT%k:%M:%SZ"
   let jformatq = "%Y-%m-%dT%k:%M:%S%QZ"
+  let ezFormat = "%Y-%m-%dT%k:%M:%S%Q%Ez"
+      dformat = "%d%m%Y"
   let b str = parseTimeM True DTF.defaultTimeLocale format str :: Maybe UTCTime
+  let c str = parseTimeM True DTF.defaultTimeLocale (T.unpack ezFormat) str :: Maybe LocalTime
+  let x str = parseTimeM True DTF.defaultTimeLocale dformat str :: Maybe LocalTime
   defaultMain [ bench "fast parse time to Maybe UTCTime" $ nf (Time.parseTime jformat) "2022-10-02T12:22:32Z"
               , bench "parse time to Maybe UTCTime" $ nf b "2022-10-02T12:22:32Z"
               , bench "fast parse time with millis to Maybe UTCTime" $ nf (Time.parseTime jformatq) "2022-10-02T12:22:32.223Z"
               , bench "fast parse day  to Maybe UTCTime" $ nf (Time.parseTime "%Y-%m %d") "2022-10-02"
+              , bench "fast parse time to Maybe LocalTime" $ nf (Time.parseLTime ezFormat)  "2020-09-10T16:01:41.395+05:30"
+              , bench "parse time to Maybe LocalTime" $ nf c "2020-09-10T16:01:41.395+05:30"
+              , bench "parse day to Maybe UTCTime" $ nf x "25012023"
+              , bench "fast parse day to Maybe UTCTime(%d%m%Y)" $ nf (Time.parseTime (T.pack dformat)) "25012023"
               ]

--- a/src/Time.hs
+++ b/src/Time.hs
@@ -3,10 +3,11 @@
 module Time
   ( module X
   , parseTime
+  , parseLTime
   ) where
 
 import Data.Text (Text)
-import Data.Time (UTCTime)
+import Data.Time (UTCTime, LocalTime)
 import FlatParse.Basic (Result(..), runParserS)
 import Time.Parser as X
 
@@ -17,10 +18,21 @@ parseTime format stringifiedDate = go $ runParserS parser stringifiedDate
       | format == "%Y-%m-%dT%k:%M:%SZ" ||
           format == "%Y-%m-%dT%k:%M:%S%QZ" ||
           format == "%Y-%m-%d %k:%M:%S%Q" || format == "%Y-%m-%d %k:%M:%S" =
-        basicParser
+        parserUTCTime
       | format == "%Y-%m-%d" ||
-          format == "%Y %m %d" || format == "%Y-%m %d" || format == "%Y %m-%d" =
+          format == "%Y %m %d" || format == "%Y-%m %d" || format == "%Y %m-%d" || format == "%Y/%-m/%-d" =
         dayParser
-      | otherwise = basicParser
+      | format == "%d%m%Y" = dayParser'
+      | otherwise = parserUTCTime
+    go (OK r _) = Just r
+    go _ = Nothing
+
+parseLTime :: Text -> String -> Maybe LocalTime 
+parseLTime format stringifiedDate = go $ runParserS parser stringifiedDate
+  where
+    parser 
+      |  format == "%Y-%m-%dT%k:%M:%S%Q%Ez" =
+        parserLocalTime
+      | otherwise = parserLocalTime
     go (OK r _) = Just r
     go _ = Nothing

--- a/src/Time/Parser.hs
+++ b/src/Time/Parser.hs
@@ -1,29 +1,33 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Time.Parser
-  ( basicParser
+  ( parserLocalTime
+  , parserUTCTime
   , dayParser
+  , dayParser'
   ) where
 
 import Data.Time
 import FlatParse.Basic
+import Data.Fixed (Pico)
 
 -- | Custom parser for the format
 -- %Y-%m-%dT%k:%M:%SZ
 -- %Y-%m-%dT%k:%M:%S%QZ
-basicParser :: Parser e UTCTime
-basicParser = do
-  (year, month, day) <- dateParser
-  satisfy_ (\x -> x == '-' || x == ' ' || x == 'T')
-  many_ $(char ' ')
-  hr <- readInteger
-  $(char ':')
-  minutes <- readInteger
-  $(char ':')
-  sec <- readInteger
-  _ <- ($(char '.') *> readInt) <|> (pure 0)
-  (try $ $(char 'Z') <|> pure ())
+-- %Y-%m-%dT%k:%M:%S%Q%Ez
+
+parserLocalTime :: Parser e LocalTime
+parserLocalTime = do 
+  (year, month, day, hr, minutes, sec) <- basicParserUtil
   pure $
-    UTCTime
+    LocalTime
+      (fromGregorian year month day)
+      (TimeOfDay (fromIntegral hr :: Int) (fromIntegral minutes :: Int) (fromIntegral sec :: Pico))
+
+parserUTCTime :: Parser e UTCTime
+parserUTCTime = do 
+  (year, month, day, hr, minutes, sec) <- basicParserUtil
+  pure $
+   UTCTime
       (fromGregorian year month day)
       (secondsToDiffTime $ (hr * 60 * 60) + (minutes * 60) + sec)
 
@@ -35,6 +39,18 @@ dayParser = do
       (fromGregorian year month day)
       (secondsToDiffTime 0)
 
+-- Added parser for handling date for this format --> "%d%m%Y" 
+dayParser' :: Parser e UTCTime
+dayParser' = do 
+  day <- isolate 2 readInt 
+  month <- isolate 2 readInt
+  year <- isolate 4 readInteger 
+  pure $ 
+   UTCTime 
+      (fromGregorian year month day)
+      (secondsToDiffTime 0)
+
+
 -- | utils
 dateParser :: Parser e (Integer, Int, Int)
 dateParser = do
@@ -44,3 +60,18 @@ dateParser = do
   satisfy_ (\x -> x == '-' || x == ' ')
   day <- readInt
   pure $ (year, month, day)
+
+-- common function for parsing time
+basicParserUtil :: Parser e (Integer, Int, Int, Integer, Integer, Integer)
+basicParserUtil = do
+  (year, month, day) <- dateParser
+  satisfy_ (\x -> x == '-' || x == ' ' || x == 'T')
+  many_ $(char ' ')
+  hr <- readInteger
+  $(char ':')
+  minutes <- readInteger
+  $(char ':')
+  sec <- readInteger
+  _ <- ($(char '.') *> readInt) <|> pure 0 
+  (try $ $(char 'Z') <|> pure ())
+  pure (year, month, day, hr, minutes, sec)


### PR DESCRIPTION
- In this commit, functions have been added to handle other date and time formats.
- Added function to parse time given in text format to LocalTime for some scenarios where we can use the LocalTime directly. 
- Added function to parse date given in format ("%d%m%Y"), in the previous function we have some conditions to check for special character, as this format doesn't have any special characters in between thus we used isolate function to fetch date from the given input.

All the bench marks with fast keyword are the implementations done using flat-parse, remaining are default methods of Haskell's Data.Time format package.

**Benchmarking stats:**

benchmarking fast parse time to Maybe UTCTime

time                 1.343 μs   (1.334 μs .. 1.350 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.339 μs   (1.333 μs .. 1.346 μs)
std dev              22.09 ns   (18.53 ns .. 25.98 ns)
variance introduced by outliers: 17% (moderately inflated)

benchmarking parse time to Maybe UTCTime
time                 15.81 μs   (15.61 μs .. 16.02 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 15.74 μs   (15.58 μs .. 16.02 μs)
std dev              669.2 ns   (378.7 ns .. 1.212 μs)
variance introduced by outliers: 51% (severely inflated)

benchmarking fast parse time with millis to Maybe UTCTime
time                 1.504 μs   (1.484 μs .. 1.523 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 1.514 μs   (1.500 μs .. 1.520 μs)
std dev              30.12 ns   (23.83 ns .. 37.26 ns)
variance introduced by outliers: 23% (moderately inflated)

benchmarking fast parse day  to Maybe UTCTime
time                 831.3 ns   (820.7 ns .. 845.5 ns)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 822.4 ns   (818.3 ns .. 835.3 ns)
std dev              21.97 ns   (11.14 ns .. 38.91 ns)
variance introduced by outliers: 36% (moderately inflated)

benchmarking fast parse time to Maybe LocalTime
time                 1.826 μs   (1.811 μs .. 1.841 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 1.793 μs   (1.773 μs .. 1.807 μs)
std dev              55.65 ns   (46.87 ns .. 64.84 ns)
variance introduced by outliers: 41% (moderately inflated)

benchmarking parse time to Maybe LocalTime
time                 21.43 μs   (21.30 μs .. 21.58 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 21.38 μs   (21.32 μs .. 21.50 μs)
std dev              269.8 ns   (136.2 ns .. 504.1 ns)

benchmarking parse day to Maybe UTCTime
time                 23.29 μs   (22.96 μs .. 23.59 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 23.01 μs   (22.90 μs .. 23.16 μs)
std dev              460.9 ns   (370.3 ns .. 657.4 ns)
variance introduced by outliers: 17% (moderately inflated)

benchmarking fast parse day to Maybe UTCTime(%d%m%Y)
time                 668.4 ns   (660.5 ns .. 677.8 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 664.7 ns   (661.0 ns .. 673.5 ns)
std dev              17.20 ns   (9.505 ns .. 28.67 ns)
variance introduced by outliers: 35% (moderately inflated)