### PR TITLE
Added support for milliseconds parsing in text time

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -10,13 +10,13 @@ import Data.Text as T
 main :: IO ()
 main = do
   let format = "%Y-%m-%dT%k:%M:%SZ"
-  let jformat = "%Y-%m-%dT%k:%M:%SZ"
-  let jformatq = "%Y-%m-%dT%k:%M:%S%QZ"
-  let ezFormat = "%Y-%m-%dT%k:%M:%S%Q%Ez"
+      jformat = "%Y-%m-%dT%k:%M:%SZ"
+      jformatq = "%Y-%m-%dT%k:%M:%S%QZ"
+      ezFormat = "%Y-%m-%dT%k:%M:%S%Q%Ez"
       dformat = "%d%m%Y"
-  let b str = parseTimeM True DTF.defaultTimeLocale format str :: Maybe UTCTime
-  let c str = parseTimeM True DTF.defaultTimeLocale (T.unpack ezFormat) str :: Maybe LocalTime
-  let x str = parseTimeM True DTF.defaultTimeLocale dformat str :: Maybe LocalTime
+      b str = parseTimeM True DTF.defaultTimeLocale (T.unpack jformatq) str :: Maybe UTCTime
+      c str = parseTimeM True DTF.defaultTimeLocale (T.unpack ezFormat) str :: Maybe LocalTime
+      x str = parseTimeM True DTF.defaultTimeLocale dformat str :: Maybe LocalTime
   defaultMain [ bench "fast parse time to Maybe UTCTime" $ nf (Time.parseTime jformat) "2022-10-02T12:22:32Z"
               , bench "parse time to Maybe UTCTime" $ nf b "2022-10-02T12:22:32Z"
               , bench "fast parse time with millis to Maybe UTCTime" $ nf (Time.parseTime jformatq) "2022-10-02T12:22:32.223Z"
@@ -25,4 +25,5 @@ main = do
               , bench "parse time to Maybe LocalTime" $ nf c "2020-09-10T16:01:41.395+05:30"
               , bench "parse day to Maybe UTCTime" $ nf x "25012023"
               , bench "fast parse day to Maybe UTCTime(%d%m%Y)" $ nf (Time.parseTime (T.pack dformat)) "25012023"
+              , bench "fast parse day to Maybe UTCTime(%Y/%-m/%-d)" $ nf (Time.parseTime "%Y/%-m/%-d") "2023/12/09"
               ]

--- a/src/Time/Parser.hs
+++ b/src/Time/Parser.hs
@@ -16,20 +16,23 @@ import Data.Fixed (Pico)
 -- %Y-%m-%dT%k:%M:%S%Q%Ez
 
 parserLocalTime :: Parser e LocalTime
-parserLocalTime = do 
-  (year, month, day, hr, minutes, sec) <- basicParserUtil
+parserLocalTime = do
+  (year, month, day, hr, minutes, sec, msec, curLen) <- basicParserUtil
+  let curLen' = if curLen < 0 then 0
+                else curLen
+      sec'    = (fromIntegral sec :: Pico) + ((fromIntegral msec :: Pico) / (10 ^ curLen' :: Pico))
   pure $
     LocalTime
       (fromGregorian year month day)
-      (TimeOfDay (fromIntegral hr :: Int) (fromIntegral minutes :: Int) (fromIntegral sec :: Pico))
+      (TimeOfDay (fromIntegral hr :: Int) (fromIntegral minutes :: Int) sec')
 
 parserUTCTime :: Parser e UTCTime
-parserUTCTime = do 
-  (year, month, day, hr, minutes, sec) <- basicParserUtil
+parserUTCTime = do
+  (year, month, day, hr, minutes, sec, msec, curLen) <- basicParserUtil
   pure $
    UTCTime
       (fromGregorian year month day)
-      (secondsToDiffTime $ (hr * 60 * 60) + (minutes * 60) + sec)
+      (picosecondsToDiffTime (((hr * 60 * 60)  + (minutes * 60) + sec) * (10 ^ 12) + (msec * (10 ^ (12 - curLen)))))
 
 dayParser :: Parser e UTCTime
 dayParser = do
@@ -41,28 +44,27 @@ dayParser = do
 
 -- Added parser for handling date for this format --> "%d%m%Y" 
 dayParser' :: Parser e UTCTime
-dayParser' = do 
-  day <- isolate 2 readInt 
+dayParser' = do
+  day <- isolate 2 readInt
   month <- isolate 2 readInt
-  year <- isolate 4 readInteger 
-  pure $ 
-   UTCTime 
+  year <- isolate 4 readInteger
+  pure $
+   UTCTime
       (fromGregorian year month day)
       (secondsToDiffTime 0)
-
 
 -- | utils
 dateParser :: Parser e (Integer, Int, Int)
 dateParser = do
   year <- readInteger
-  satisfy_ (\x -> x == '-' || x == ' ')
+  satisfy_ (\x -> x == '-' || x == ' ' || x == '/')
   month <- readInt
-  satisfy_ (\x -> x == '-' || x == ' ')
+  satisfy_ (\x -> x == '-' || x == ' ' || x == '/')
   day <- readInt
-  pure $ (year, month, day)
+  pure (year, month, day)
 
 -- common function for parsing time
-basicParserUtil :: Parser e (Integer, Int, Int, Integer, Integer, Integer)
+basicParserUtil :: Parser e (Integer, Int, Int, Integer, Integer, Integer, Integer, Int)
 basicParserUtil = do
   (year, month, day) <- dateParser
   satisfy_ (\x -> x == '-' || x == ' ' || x == 'T')
@@ -72,6 +74,8 @@ basicParserUtil = do
   minutes <- readInteger
   $(char ':')
   sec <- readInteger
-  _ <- ($(char '.') *> readInt) <|> pure 0 
-  (try $ $(char 'Z') <|> pure ())
-  pure (year, month, day, hr, minutes, sec)
+  Pos curS <- getPos
+  msec <- ($(char '.') *> readInteger) <|> pure 0
+  Pos curE <- getPos
+  try $ $(char 'Z') <|> pure ()
+  pure (year, month, day, hr, minutes, sec, msec, curS - curE -1)


### PR DESCRIPTION
In this PR we have added support for parsing milliseconds for both LocalTime & UTCTime.
Some of the testcases are attached below:
| Input | Output |
| ---- | ---- | 
| 2020-09-10T16:01:41.395453954539+05:30 |  2020-09-10 16:01:41.395453954539 | 
| 2020-09-10T16:01:41.395+05:30 | 2020-09-10 16:01:41.395 | 
| 2022-10-02T12:22:32.223Z | 2022-10-02 12:22:32.223 UTC |

Benchmarking stats are shown below:
| BenchMark Name | Description | Time | FastTime | Previous Version Fast-Time | Remarks |
| ---- | ---- | ---- | ---- | ---- | ---- |
| UTCTime| Converts TextTime to UTCTime | time --> 10.61 μs   (10.55 μs .. 10.70 μs)  46% (moderately inflated)| fast-time --> 907.2 ns   (898.1 ns .. 915.4 ns) | fast-time --> 847.4 ns   (842.0 ns .. 852.3 ns)  | NA |
| UTCTime in Milliseconds | Converts the Text time to UTCTime covering the case of milliseconds in the text time | time --> 10.61 μs   (10.55 μs .. 10.70 μs)   | fast-time --> 1.007 μs   (1.002 μs .. 1.012 μs) | fast-time --> 931.1 ns   (926.6 ns .. 936.1 ns) | PR version is also parsing the milliseconds in the final output as compared to the previous version |
LocalTime |  Converts Text time to LocalTime | time 13.97 μs   (13.74 μs .. 14.25 μs) | fast-time 1.364 μs   (1.353 μs .. 1.375 μs)| Method not available | NA |
DateParsing | Converts the date in various formats to UTCTime Format((%d%m%Y), (%Y/%-m/%-d), ("%Y-%m-%d") etc.) | time --> 14.58 μs   (14.50 μs .. 14.68 μs) | fast-time --> 532.0 ns   (530.1 ns .. 533.5 ns)| fast-time --> 548.4 ns   (545.4 ns .. 552.2 ns)| PR version is the average of all possible implementations for handling different methods, as we have a different implementation for this format (%d%m%Y) while the old version timings are related to a common implementation for remaining date formats.