### PR TITLE
Updated the readme file and the ghc-options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fast-time
 
-## A custom parsers using flatparse for data-time.
+## A custom date time parser made using flatparse
 
 
 ### Supported Formats of Date & Time 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,33 @@
 # fast-time
 
-A custom parsers using flatparse for data-time.
+## A custom parsers using flatparse for data-time.
 
-## TODO
 
-- Need to add more foramts.
+### Supported Formats of Date & Time 
+#### Date-Time Formats  
+
+- "%Y-%m-%dT%k:%M:%SZ"
+- "%Y-%m-%dT%k:%M:%S%QZ"
+- "%Y-%m-%d %k:%M:%S%Q" 
+- "%Y-%m-%d %k:%M:%S" 
+- "%Y-%m-%dT%k:%M:%S%Q%Ez"
+
+#### Date Formats 
+
+- "%Y-%m-%d"
+- "%Y %m %d"
+- "%Y-%m %d"
+- "%Y %m-%d" 
+- "%Y/%-m/%-d"
+- "%d%m%Y"
+
+### Benchmarks 
+
+| Benchmark Name | Description | Data.Time Library | Fast-time | 
+| ----- | ----- | ----- | ----- | 
+| UTCTime | Converts the text time to UTCTime format. | 8.382 μs   (8.359 μs .. 8.425 μs) | 734.4 ns   (731.7 ns .. 736.4 ns) |
+| UTCTime Milliseconds | Converts the text time which includes millisecond to UTCTime format. | 11.28 μs   (11.24 μs .. 11.33 μs) | 806.6 ns   (804.4 ns .. 808.8 ns) | 
+| LocalTime | Converts the text time to Local time covering case of millisecond parsing as well. | 11.67 μs   (11.53 μs .. 11.81 μs | 1.200 μs   (1.180 μs .. 1.220 μs) | 
+| Date Parsing | Converts the text date in the given format. | 4.710 μs   (4.296 μs .. 5.211 μs) | 440.3 ns   (437.4 ns .. 443.6 ns) | 
+| Date Parsing ("%d%m%Y") | Converts the text date to the given format using isolate method of flatparse library. | 12.08 μs   (11.81 μs .. 12.29 μs) | 368.1 ns   (359.7 ns .. 378.0 ns) |
+

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -14,16 +14,23 @@ main = do
       jformatq = "%Y-%m-%dT%k:%M:%S%QZ"
       ezFormat = "%Y-%m-%dT%k:%M:%S%Q%Ez"
       dformat = "%d%m%Y"
+      dformat2 = "%Y-%m-%d"
+      dformat3 = "%Y/%-m/%-d"
       b str = parseTimeM True DTF.defaultTimeLocale (T.unpack jformatq) str :: Maybe UTCTime
       c str = parseTimeM True DTF.defaultTimeLocale (T.unpack ezFormat) str :: Maybe LocalTime
-      x str = parseTimeM True DTF.defaultTimeLocale dformat str :: Maybe LocalTime
+      x str = parseTimeM True DTF.defaultTimeLocale dformat str :: Maybe UTCTime
+      y str = parseTimeM True DTF.defaultTimeLocale dformat2 str :: Maybe UTCTime 
+      z str = parseTimeM True DTF.defaultTimeLocale dformat3 str :: Maybe UTCTime
   defaultMain [ bench "fast parse time to Maybe UTCTime" $ nf (Time.parseTime jformat) "2022-10-02T12:22:32Z"
-              , bench "parse time to Maybe UTCTime" $ nf b "2022-10-02T12:22:32Z"
+              , bench "parse time to Maybe UTCTime using Data.Time package" $ nf b "2022-10-02T12:22:32Z"
               , bench "fast parse time with millis to Maybe UTCTime" $ nf (Time.parseTime jformatq) "2022-10-02T12:22:32.223Z"
+              , bench "parse time to Maybe millis UTCTime using Data.Time package" $ nf b "2022-10-02T12:22:32.223Z"
               , bench "fast parse day  to Maybe UTCTime" $ nf (Time.parseTime "%Y-%m %d") "2022-10-02"
+              , bench "parse day using the Data.Time package" $ nf y "2022-10-02"
               , bench "fast parse time to Maybe LocalTime" $ nf (Time.parseLTime ezFormat)  "2020-09-10T16:01:41.395+05:30"
-              , bench "parse time to Maybe LocalTime" $ nf c "2020-09-10T16:01:41.395+05:30"
-              , bench "parse day to Maybe UTCTime" $ nf x "25012023"
+              , bench "parse time to Maybe LocalTime using Data.Time package" $ nf c "2020-09-10T16:01:41.395+05:30"
               , bench "fast parse day to Maybe UTCTime(%d%m%Y)" $ nf (Time.parseTime (T.pack dformat)) "25012023"
+              , bench "parse day to Maybe UTCTime using Data.Time package" $ nf x "25012023"
               , bench "fast parse day to Maybe UTCTime(%Y/%-m/%-d)" $ nf (Time.parseTime "%Y/%-m/%-d") "2023/12/09"
+              , bench "parse day using Data.Time package" $ nf z "2023/12/09"
               ]

--- a/fast-time.cabal
+++ b/fast-time.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -46,7 +46,7 @@ executable fast-time-bench
       Paths_fast_time
   hs-source-dirs:
       bench
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -O2 -with-rtsopts=-N1
   build-depends:
       base >=4.7 && <5
     , criterion
@@ -62,7 +62,7 @@ executable fast-time-exe
       Paths_fast_time
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -O2 -with-rtsopts=-N1
   build-depends:
       base >=4.7 && <5
     , fast-time
@@ -78,7 +78,7 @@ test-suite fast-time-test
       Paths_fast_time
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -O2 -with-rtsopts=-N1
   build-depends:
       base >=4.7 && <5
     , fast-time

--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,8 @@ executables:
     ghc-options:
       - -threaded
       - -rtsopts
-      - -with-rtsopts=-N
+      - -O2
+      - -with-rtsopts=-N1
     dependencies:
       - fast-time
   fast-time-bench:
@@ -55,7 +56,8 @@ executables:
     ghc-options:
       - -threaded
       - -rtsopts
-      - -with-rtsopts=-N
+      - -O2
+      - -with-rtsopts=-N1
     dependencies:
       - fast-time
       - criterion
@@ -67,6 +69,7 @@ tests:
     ghc-options:
       - -threaded
       - -rtsopts
-      - -with-rtsopts=-N
+      - -O2
+      - -with-rtsopts=-N1
     dependencies:
       - fast-time


### PR DESCRIPTION
In this PR we have updated the ReadMe file and ghc-options. 
Readme file contains information about all the date-time formats supported by fast-time library along with the benchmarks compared with Data.Time library in haskell.
Changes done in ghc-options are:
- O2 Optimisation 
- -with-rtsopts=-N has been changed to -with-rtsopts=-N1