### PR TITLE
Fixed parser

### DIFF
--- a/fast-time.cabal
+++ b/fast-time.cabal
@@ -28,6 +28,7 @@ library
       Lib
       Time
       Time.Parser
+      Utils.ReadInteger
   other-modules:
       Paths_fast_time
   hs-source-dirs:
@@ -38,6 +39,7 @@ library
     , flatparse
     , text
     , time
+    , bytestring
   default-language: Haskell2010
 
 executable fast-time-bench
@@ -54,6 +56,7 @@ executable fast-time-bench
     , flatparse
     , text
     , time
+    , bytestring
   default-language: Haskell2010
 
 executable fast-time-exe
@@ -85,4 +88,5 @@ test-suite fast-time-test
     , flatparse
     , text
     , time
+    , bytestring
   default-language: Haskell2010

--- a/src/Time.hs
+++ b/src/Time.hs
@@ -8,11 +8,12 @@ module Time
 
 import Data.Text (Text)
 import Data.Time (UTCTime, LocalTime)
-import FlatParse.Basic (Result(..), runParserS)
+import FlatParse.Basic (Result(..), runParser)
 import Time.Parser as X
+import qualified Data.ByteString.Char8 as B
 
 parseTime :: Text -> String -> Maybe UTCTime
-parseTime format stringifiedDate = go $ runParserS parser stringifiedDate
+parseTime format stringifiedDate = go $ runParser parser (B.pack stringifiedDate)
   where
     parser
       | format == "%Y-%m-%dT%k:%M:%SZ" ||
@@ -28,7 +29,7 @@ parseTime format stringifiedDate = go $ runParserS parser stringifiedDate
     go _ = Nothing
 
 parseLTime :: Text -> String -> Maybe LocalTime 
-parseLTime format stringifiedDate = go $ runParserS parser stringifiedDate
+parseLTime format stringifiedDate = go $ runParser parser (B.pack stringifiedDate)
   where
     parser 
       |  format == "%Y-%m-%dT%k:%M:%S%Q%Ez" =

--- a/src/Time/Parser.hs
+++ b/src/Time/Parser.hs
@@ -9,6 +9,7 @@ module Time.Parser
 import Data.Time
 import FlatParse.Basic
 import Data.Fixed (Pico)
+import Utils.ReadInteger
 
 -- | Custom parser for the format
 -- %Y-%m-%dT%k:%M:%SZ
@@ -45,9 +46,9 @@ dayParser = do
 -- Added parser for handling date for this format --> "%d%m%Y" 
 dayParser' :: Parser e UTCTime
 dayParser' = do
-  day <- isolate 2 readInt
-  month <- isolate 2 readInt
-  year <- isolate 4 readInteger
+  day <- isolate 2 readDayOfMonth
+  month <- isolate 2 readMonthOfYear
+  year <- isolate 4 readYear
   pure $
    UTCTime
       (fromGregorian year month day)
@@ -56,19 +57,19 @@ dayParser' = do
 -- | utils
 dateParser :: Parser e (Integer, Int, Int)
 dateParser = do
-  year <- readInteger
-  satisfy_ (\x -> x == '-' || x == ' ' || x == '/')
-  month <- readInt
-  satisfy_ (\x -> x == '-' || x == ' ' || x == '/')
-  day <- readInt
+  year <- readYear
+  satisfy (\x -> x == '-' || x == ' ' || x == '/')
+  month <- readMonthOfYear
+  satisfy (\x -> x == '-' || x == ' ' || x == '/')
+  day <- readDayOfMonth
   pure (year, month, day)
 
 -- common function for parsing time
 basicParserUtil :: Parser e (Integer, Int, Int, Integer, Integer, Integer, Integer, Int)
 basicParserUtil = do
   (year, month, day) <- dateParser
-  satisfy_ (\x -> x == '-' || x == ' ' || x == 'T')
-  many_ $(char ' ')
+  satisfy (\x -> x == '-' || x == ' ' || x == 'T')
+  many $(char ' ')
   hr <- readInteger
   $(char ':')
   minutes <- readInteger

--- a/src/Utils/ReadInteger.hs
+++ b/src/Utils/ReadInteger.hs
@@ -1,0 +1,20 @@
+
+module Utils.ReadInteger where
+
+import FlatParse.Basic as FB
+import Data.Time.Calendar ( DayOfMonth, MonthOfYear, Year )
+
+readInt :: Parser e Int
+readInt     = FB.anyAsciiDecimalInt
+
+readInteger :: Parser e Integer
+readInteger = FB.anyAsciiDecimalInteger
+
+readDayOfMonth :: Parser e DayOfMonth
+readDayOfMonth = FB.anyAsciiDecimalInt
+
+readMonthOfYear :: Parser e MonthOfYear
+readMonthOfYear = FB.anyAsciiDecimalInt
+
+readYear :: Parser e Year
+readYear = FB.anyAsciiDecimalInteger


### PR DESCRIPTION
Fixed few deprecated functions - readInt, readInteger, satisfy and many which got deprecated in the newer version of flatparse library that fast-time use.